### PR TITLE
[gpt-oss] Parse output msgs refactor

### DIFF
--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -324,7 +324,121 @@ def render_for_completion(messages: list[Message]) -> list[int]:
     return token_ids
 
 
-# TODO: refactor function and mcp call logic into sub functions
+def _parse_browser_tool_call(message: Message, recipient: str) -> ResponseOutputItem:
+    """Parse browser tool calls (search, open, find) into web search items."""
+    if len(message.content) != 1:
+        raise ValueError("Invalid number of contents in browser message")
+    content = message.content[0]
+
+    # Parse JSON args (with retry detection)
+    try:
+        browser_call = json.loads(content.text)
+    except json.JSONDecodeError:
+        json_retry_output_message = (
+            f"Invalid JSON args, caught and retried: {content.text}"
+        )
+        browser_call = {
+            "query": json_retry_output_message,
+            "url": json_retry_output_message,
+            "pattern": json_retry_output_message,
+        }
+
+    # Create appropriate action based on recipient
+    if recipient == "browser.search":
+        action = ActionSearch(
+            query=f"cursor:{browser_call.get('query', '')}", type="search"
+        )
+    elif recipient == "browser.open":
+        action = ActionOpenPage(
+            url=f"cursor:{browser_call.get('url', '')}", type="open_page"
+        )
+    elif recipient == "browser.find":
+        action = ActionFind(
+            pattern=browser_call["pattern"],
+            url=f"cursor:{browser_call.get('url', '')}",
+            type="find",
+        )
+    else:
+        raise ValueError(f"Unknown browser action: {recipient}")
+
+    return ResponseFunctionWebSearch(
+        id=f"ws_{random_uuid()}",
+        action=action,
+        status="completed",
+        type="web_search_call",
+    )
+
+
+def _parse_function_call(message: Message, recipient: str) -> list[ResponseOutputItem]:
+    """Parse function calls into function tool call items."""
+    function_name = recipient.split(".")[-1]
+    output_items = []
+    for content in message.content:
+        response_item = ResponseFunctionToolCall(
+            arguments=content.text,
+            call_id=f"call_{random_uuid()}",
+            type="function_call",
+            name=function_name,
+            id=f"fc_{random_uuid()}",
+        )
+        output_items.append(response_item)
+    return output_items
+
+
+def _parse_mcp_call(message: Message, recipient: str) -> list[ResponseOutputItem]:
+    """Parse MCP calls into MCP call items."""
+    mcp_name = recipient.split(".")[-1] if "." in recipient else recipient
+    output_items = []
+    for content in message.content:
+        response_item = McpCall(
+            arguments=content.text,
+            type="mcp_call",
+            name=mcp_name,
+            id=f"mcp_{random_uuid()}",
+            status="completed",
+        )
+        output_items.append(response_item)
+    return output_items
+
+
+def _parse_reasoning_content(message: Message) -> list[ResponseOutputItem]:
+    """Parse reasoning/analysis content into reasoning items."""
+    output_items = []
+    for content in message.content:
+        reasoning_item = ResponseReasoningItem(
+            id=f"rs_{random_uuid()}",
+            summary=[],
+            type="reasoning",
+            content=[
+                ResponseReasoningTextContent(text=content.text, type="reasoning_text")
+            ],
+            status=None,
+        )
+        output_items.append(reasoning_item)
+    return output_items
+
+
+def _parse_final_message(message: Message) -> ResponseOutputItem:
+    """Parse final message into output message item."""
+    contents = []
+    for content in message.content:
+        output_text = ResponseOutputText(
+            text=content.text,
+            annotations=[],
+            type="output_text",
+            logprobs=None,
+        )
+        contents.append(output_text)
+
+    return ResponseOutputMessage(
+        id=f"msg_{random_uuid()}",
+        content=contents,
+        role=message.author.role,
+        status="completed",
+        type="message",
+    )
+
+
 def parse_output_message(message: Message) -> list[ResponseOutputItem]:
     """
     Parse a Harmony message into a list of output response items.
@@ -341,131 +455,29 @@ def parse_output_message(message: Message) -> list[ResponseOutputItem]:
     if recipient is not None:
         # Handle browser tools (special case with JSON parsing)
         if recipient.startswith("browser."):
-            if len(message.content) != 1:
-                raise ValueError("Invalid number of contents in browser message")
-            content = message.content[0]
-            # We do not need to check the VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY
-            # env variable since if it is not set, we are certain the json is
-            # valid. The use of Actions for web search will be removed entirely
-            # in the future, so this is only necessary temporarily
-            try:
-                browser_call = json.loads(content.text)
-            except json.JSONDecodeError:
-                # If the content is not valid JSON, then it was
-                # caught and retried by vLLM, which means we
-                # need to make note of that so the user is aware
-                json_retry_output_message = (
-                    f"Invalid JSON args, caught and retried: {content.text}"
-                )
-                browser_call = {
-                    "query": json_retry_output_message,
-                    "url": json_retry_output_message,
-                    "pattern": json_retry_output_message,
-                }
-            # TODO: translate to url properly!
-            if recipient == "browser.search":
-                action = ActionSearch(
-                    query=f"cursor:{browser_call.get('query', '')}", type="search"
-                )
-            elif recipient == "browser.open":
-                action = ActionOpenPage(
-                    url=f"cursor:{browser_call.get('url', '')}", type="open_page"
-                )
-            elif recipient == "browser.find":
-                action = ActionFind(
-                    pattern=browser_call["pattern"],
-                    url=f"cursor:{browser_call.get('url', '')}",
-                    type="find",
-                )
-            else:
-                raise ValueError(f"Unknown browser action: {recipient}")
-            web_search_item = ResponseFunctionWebSearch(
-                id=f"ws_{random_uuid()}",
-                action=action,
-                status="completed",
-                type="web_search_call",
-            )
-            output_items.append(web_search_item)
-        # Handle function calls (starts with "functions.")
+            browser_item = _parse_browser_tool_call(message, recipient)
+            output_items.append(browser_item)
+        # Handle function calls
         elif recipient.startswith("functions."):
-            function_name = recipient.split(".")[-1]
-            for content in message.content:
-                response_item = ResponseFunctionToolCall(
-                    arguments=content.text,
-                    call_id=f"call_{random_uuid()}",
-                    type="function_call",
-                    name=function_name,
-                    id=f"fc_{random_uuid()}",
-                )
-                output_items.append(response_item)
+            output_items.extend(_parse_function_call(message, recipient))
         # Handle built-in tools (python, browser, container) - treat as reasoning
         elif (
             recipient.startswith("python")
             or recipient.startswith("browser")
             or recipient.startswith("container")
         ):
-            for content in message.content:
-                reasoning_item = ResponseReasoningItem(
-                    id=f"rs_{random_uuid()}",
-                    summary=[],
-                    type="reasoning",
-                    content=[
-                        ResponseReasoningTextContent(
-                            text=content.text, type="reasoning_text"
-                        )
-                    ],
-                    status=None,
-                )
-                output_items.append(reasoning_item)
+            output_items.extend(_parse_reasoning_content(message))
+        # Handle MCP calls
         else:
-            mcp_name = recipient.split(".")[-1] if "." in recipient else recipient
-            for content in message.content:
-                random_id = random_uuid()
-                response_item = McpCall(
-                    arguments=content.text,
-                    type="mcp_call",
-                    name=mcp_name,
-                    id=f"mcp_{random_id}",
-                    status="completed",
-                )
-                output_items.append(response_item)
-    # No recipient - handle based on channel for non-tool messages
+            output_items.extend(_parse_mcp_call(message, recipient))
+    # No recipient - handle based on channel
     elif message.channel == "analysis":
-        # Regular reasoning content
-        for content in message.content:
-            reasoning_item = ResponseReasoningItem(
-                id=f"rs_{random_uuid()}",
-                summary=[],
-                type="reasoning",
-                content=[
-                    ResponseReasoningTextContent(
-                        text=content.text, type="reasoning_text"
-                    )
-                ],
-                status=None,
-            )
-            output_items.append(reasoning_item)
+        output_items.extend(_parse_reasoning_content(message))
     elif message.channel == "commentary":
-        # Commentary channel without recipient shouldn't happen
         raise ValueError(f"Commentary channel message without recipient: {message}")
     elif message.channel == "final":
-        contents = []
-        for content in message.content:
-            output_text = ResponseOutputText(
-                text=content.text,
-                annotations=[],  # TODO
-                type="output_text",
-                logprobs=None,  # TODO
-            )
-            contents.append(output_text)
-        text_item = ResponseOutputMessage(
-            id=f"msg_{random_uuid()}",
-            content=contents,
-            role=message.author.role,
-            status="completed",
-            type="message",
-        )
-        output_items.append(text_item)
+        final_item = _parse_final_message(message)
+        output_items.append(final_item)
     else:
         raise ValueError(f"Unknown channel: {message.channel}")
     return output_items


### PR DESCRIPTION
## Purpose

  Refactor `parse_output_message` function in
  `vllm/entrypoints/harmony_utils.py` to improve code
  maintainability and readability. The function was
  becoming too complex with multiple nested conditional
   branches for handling browser tools, function calls,
   MCP calls, and message parsing.

  This PR extracts the logic into focused
  sub-functions:
  - `_parse_browser_tool_call()` - Handles browser tool
   calls with JSON parsing
  - `_parse_function_call()` - Handles function calls
  - `_parse_mcp_call()` - Handles MCP calls
  - `_parse_reasoning_content()` - Handles
  reasoning/analysis content
  - `_parse_final_message()` - Handles final message
  output

  No functional changes - purely a code organization
  improvement.

  ## Test Plan

  Run existing tests to ensure no behavioral chang