### PR TITLE
Improve Responses API input validation for multi-turn

### DIFF
--- a/tests/entrypoints/openai/test_response_api_mcp_tools.py
+++ b/tests/entrypoints/openai/test_response_api_mcp_tools.py
@@ -206,6 +206,67 @@ async def test_mcp_tool_env_flag_disabled(mcp_disabled_client: OpenAI, model_nam
         )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_mcp_tool_calling_streaming_types(
+    mcp_enabled_client: OpenAI, model_name: str
+):
+    pairs_of_event_types = {
+        "response.completed": "response.created",
+        "response.output_item.done": "response.output_item.added",
+        "response.content_part.done": "response.content_part.added",
+        "response.output_text.done": "response.output_text.delta",
+        "response.reasoning_text.done": "response.reasoning_text.delta",
+        "response.reasoning_part.done": "response.reasoning_part.added",
+        "response.mcp_call_arguments.done": "response.mcp_call_arguments.delta",
+        "response.mcp_call.completed": "response.mcp_call.in_progress",
+    }
+
+    tools = [
+        {
+            "type": "mcp",
+            "server_label": "code_interpreter",
+        }
+    ]
+    input_text = "What is 123 * 456? Use python to calculate the result."
+
+    stream_response = await mcp_enabled_client.responses.create(
+        model=model_name,
+        input=input_text,
+        tools=tools,
+        stream=True,
+        instructions=(
+            "You must use the Python tool to execute code. Never simulate execution."
+        ),
+    )
+
+    stack_of_event_types = []
+    saw_mcp_type = False
+    async for event in stream_response:
+        if event.type == "response.created":
+            stack_of_event_types.append(event.type)
+        elif event.type == "response.completed":
+            assert stack_of_event_types[-1] == pairs_of_event_types[event.type]
+            stack_of_event_types.pop()
+        if (
+            event.type.endswith("added")
+            or event.type == "response.mcp_call.in_progress"
+        ):
+            stack_of_event_types.append(event.type)
+        elif event.type.endswith("delta"):
+            if stack_of_event_types[-1] == event.type:
+                continue
+            stack_of_event_types.append(event.type)
+        elif event.type.endswith("done") or event.type == "response.mcp_call.completed":
+            assert stack_of_event_types[-1] == pairs_of_event_types[event.type]
+            if "mcp_call" in event.type:
+                saw_mcp_type = True
+            stack_of_event_types.pop()
+
+    assert len(stack_of_event_types) == 0
+    assert saw_mcp_type, "Should have seen at least one mcp call"
+
+
 def test_get_tool_description():
     """Test MCPToolServer.get_tool_description filtering logic.
 


### PR DESCRIPTION
## Purpose
  Enhance the function_call_parsing validator to handle
  common client
  serialization variations when echoing previous
  responses:

  - Strip null/None values from input items before
  validation
  - Auto-generate missing IDs for reasoning items
  - Normalize output content types to input types in
  messages
  - Handle both dict and Pydantic model inputs
  consistently

  These changes make the API more robust when clients
  send back
  previous response items as input in multi-turn
  conversations.

## Test Plan
Inside codex prompt: 

 
› refactor parse output msgs in vllm/entrypoints/
  harmony_utils.py
  
  
## Test Result

Server side:

^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:16:40 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:16:41 [loggers.py:236] Engine 000: Avg prompt throughput: 1560.3 tokens/s, Avg generation throughput: 120.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 4.5%, Prefix cache hit rate: 45.2%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:16:51 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 119.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 4.9%, Prefix cache hit rate: 45.2%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:17:01 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 117.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 5.2%, Prefix cache hit rate: 45.2%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:17:02 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:17:11 [loggers.py:236] Engine 000: Avg prompt throughput: 1815.9 tokens/s, Avg generation throughput: 112.4 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 5.5%, Prefix cache hit rate: 61.0%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:17:21 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 111.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 5.9%, Prefix cache hit rate: 61.0%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:17:24 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:17:31 [loggers.py:236] Engine 000: Avg prompt throughput: 2071.5 tokens/s, Avg generation throughput: 107.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 6.2%, Prefix cache hit rate: 69.2%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:17:41 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 109.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 6.5%, Prefix cache hit rate: 69.2%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:17:48 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:17:51 [loggers.py:236] Engine 000: Avg prompt throughput: 2329.3 tokens/s, Avg generation throughput: 105.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 6.8%, Prefix cache hit rate: 74.3%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:18:01 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 104.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 7.1%, Prefix cache hit rate: 74.3%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:18:11 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 103.2 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 7.4%, Prefix cache hit rate: 74.3%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:18:13 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:18:21 [loggers.py:236] Engine 000: Avg prompt throughput: 2586.4 tokens/s, Avg generation throughput: 98.3 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 7.7%, Prefix cache hit rate: 77.8%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:18:31 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 100.0 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 7.9%, Prefix cache hit rate: 77.8%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:18:39 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:18:41 [loggers.py:236] Engine 000: Avg prompt throughput: 2842.3 tokens/s, Avg generation throughput: 96.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 8.2%, Prefix cache hit rate: 80.4%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:18:51 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 97.4 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 8.5%, Prefix cache hit rate: 80.4%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:19:01 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 96.0 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 8.8%, Prefix cache hit rate: 80.4%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:19:06 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:19:11 [loggers.py:236] Engine 000: Avg prompt throughput: 3100.8 tokens/s, Avg generation throughput: 92.5 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 9.0%, Prefix cache hit rate: 82.3%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:19:21 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 93.3 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 9.3%, Prefix cache hit rate: 82.3%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:19:31 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 92.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 9.6%, Prefix cache hit rate: 82.3%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:19:34 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:19:41 [loggers.py:236] Engine 000: Avg prompt throughput: 3357.9 tokens/s, Avg generation throughput: 89.0 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 9.8%, Prefix cache hit rate: 83.9%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:19:51 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 89.5 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 10.1%, Prefix cache hit rate: 83.9%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:20:01 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 88.5 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 10.3%, Prefix cache hit rate: 83.9%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:20:03 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:20:11 [loggers.py:236] Engine 000: Avg prompt throughput: 3621.6 tokens/s, Avg generation throughput: 85.4 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 10.6%, Prefix cache hit rate: 85.2%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:20:21 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 85.8 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 10.8%, Prefix cache hit rate: 85.2%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:20:31 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 85.4 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 11.1%, Prefix cache hit rate: 85.2%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:20:34 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:20:35 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:20:41 [loggers.py:236] Engine 000: Avg prompt throughput: 7771.6 tokens/s, Avg generation throughput: 81.9 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 11.3%, Prefix cache hit rate: 87.9%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:20:51 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 84.0 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 11.6%, Prefix cache hit rate: 87.9%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:21:01 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 83.0 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 11.8%, Prefix cache hit rate: 87.9%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:21:05 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:21:11 [loggers.py:236] Engine 000: Avg prompt throughput: 4147.6 tokens/s, Avg generation throughput: 80.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 12.0%, Prefix cache hit rate: 88.6%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:21:21 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 81.5 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 12.3%, Prefix cache hit rate: 88.6%
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:21:31 [loggers.py:236] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 70.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 12.5%, Prefix cache hit rate: 88.6%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:21:40 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO 11-17 14:21:41 [loggers.py:236] Engine 000: Avg prompt throughput: 4421.2 tokens/s, Avg generation throughput: 76.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 12.7%, Prefix cache hit rate: 89.2%
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:21:42 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK
^[[1;36m(APIServer pid=3168319)^[[0;0m WARNING 11-17 14:21:44 [protocol.py:126] The following fields were present in the request but ignored: {'prompt_cache_key'}
^[[1;36m(APIServer pid=3168319)^[[0;0m INFO:     127.0.0.1:65258 - "POST /v1/responses HTTP/1.1" 200 OK

Client side:

Implemented a comprehensive refactor of
  parse_output_message in vllm/entrypoints/harmony_utils.py:

  - Added detailed docstring and clarified.
    Streamlined assistant role handling and early for
    non‑assistant messages.
  - Reorganized logic with clear sections browser actions,
    analysis, commentary, and final channels.
  - Simplified JSON handling for browser calls with
    placeholder fallback.
  - Utilized descriptive variable names and removed redundant
    comments.
  - Consolidated output item creation for each channel type.
  - Ensured consistent error handling for unknown channels
    or recipients.